### PR TITLE
feat: support native brotli

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -7,7 +7,7 @@ const Svgo = require('svgo')
 const zlib = require('zlib')
 const { promisify } = require('util')
 const gzip = promisify(zlib.gzip)
-const br = require('iltorb')
+const br = require('zlib').brotliCompress ? promisify(require('zlib').brotliCompress) : require('iltorb').compress
 const micromatch = require('micromatch')
 
 const isMatch = (path, patterns, options) => {
@@ -194,7 +194,7 @@ function brotliFn () {
           const input = Buffer.from(assetTxt, 'utf-8')
 
           try {
-            const result = await br.compress(input)
+            const result = await br(input)
             if (options.logger) verbose.call(this, input, result.toString(), path, 'brotli')
             resolve(route.set(path + '.br', result))
           } catch (err) {


### PR DESCRIPTION
Closes #13 

This plugin will drop iltorb after Node 8 reaches EOL (2019/12/31).

Tested on Node 12 & 8.