### PR TITLE
fix: use html-minifier-terser instead of html-minifier

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { minify: htmlMinify } = require('html-minifier')
+const { minify: htmlMinify } = require('html-minifier-terser')
 const CleanCSS = require('clean-css')
 const { minify: terserMinify } = require('terser')
 const Svgo = require('svgo')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "repository": "curbengh/hexo-yam",
   "dependencies": {
     "clean-css": "^4.2.1",
-    "html-minifier": "^4.0.0",
+    "html-minifier-terser": "^5.1.1",
     "micromatch": "^4.0.2",
     "minify-xml": "^2.1.1",
     "svgo": "^1.2.2",

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const Hexo = require('hexo')
-const { minify: htmlMinify } = require('html-minifier')
+const { minify: htmlMinify } = require('html-minifier-terser')
 
 describe('html', () => {
   const hexo = new Hexo(__dirname)


### PR DESCRIPTION
html-minifier-terser was developed based on html-minifier, and the difference
between them is that html-minifier-terser can minify inline ES6 scripts in html
file, but html-minifier cannot.

closes #30