### PR TITLE
chore(deps): bump svgo from 1.3.2 to 2.3.0 (BREAKING CHANGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,16 @@ minify:
 - **include** - Include files. Support [wildcard](http://www.globtester.com/) pattern(s) in a string or array.
   - Exclude `*.min.svg` by default.
 - **plugins** - Plugin options.
-  - Example: to retain comments, `plugins: [{removeComments: false}]`.
+  - Examples:
+  ``` yaml
+  plugins:
+    # Retain comments
+    - name: 'removeComments'
+      active: false
+    # Do not remove unused ID attributes
+    - name: 'cleanupIDs'
+      active: false
+  ```
   - For more options, see [svgo](https://github.com/svg/svgo).
 - **globOptions** - See [globbing](#globbing) section.
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /* global hexo */
 'use strict'
 
+const { extendDefaultPlugins } = require('svgo')
+
 hexo.config.minify = Object.assign({
   enable: true
 }, hexo.config.minify)
@@ -48,7 +50,7 @@ hexo.config.minify.svg = Object.assign({
   priority: 10,
   verbose: false,
   include: ['*.svg', '!*.min.svg'],
-  plugins: [],
+  plugins: extendDefaultPlugins([]),
   globOptions: { basename: true }
 }, hexo.config.minify.svg)
 

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -3,7 +3,7 @@
 const { minify: htmlMinify } = require('html-minifier')
 const CleanCSS = require('clean-css')
 const { minify: terserMinify } = require('terser')
-const Svgo = require('svgo')
+const { optimize: svgOptimize, extendDefaultPlugins } = require('svgo')
 const zlib = require('zlib')
 const { promisify } = require('util')
 const gzip = promisify(zlib.gzip)
@@ -136,6 +136,7 @@ function minifySvg () {
   const { route } = hexo
   const routeList = route.list()
   const { globOptions, include, verbose } = options
+  const plugins = Array.isArray(options.plugins) ? extendDefaultPlugins(options.plugins) : extendDefaultPlugins([])
 
   return Promise.all((match(routeList, include, globOptions)).map((path) => {
     return new Promise((resolve, reject) => {
@@ -144,12 +145,12 @@ function minifySvg () {
       assetPath.on('data', (chunk) => (assetTxt += chunk))
       assetPath.on('end', async () => {
         if (assetTxt.length) {
-          try {
-            const { data } = await new Svgo(options).optimize(assetTxt)
+          const { data, error } = svgOptimize(assetTxt, { ...options, plugins })
+          if (data) {
             if (verbose) logFn.call(this, assetTxt, data, path, 'svg')
             resolve(route.set(path, data))
-          } catch (err) {
-            reject(new Error(`Path: ${path}\n${err}`))
+          } else if (error) {
+            reject(new Error(`Path: ${path}\n${error}`))
           }
         }
         resolve()

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "html-minifier": "^4.0.0",
     "micromatch": "^4.0.2",
     "minify-xml": "^2.1.1",
-    "svgo": "^1.2.2",
+    "svgo": "^2.3.0",
     "terser": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- BREAKING CHANGE: syntax of minify.svg.plugins option
  * https://github.com/svg/svgo/releases/tag/v2.0.0
  * add a new test to check type of `plugins` variable (must be array)
- svgo optimize() changed from async to sync
- Closes #50 