### PR TITLE
release: 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hexo-yam",
   "description": "Yet Another Minifier. Minify and compress html, js, css, svg, xml and json",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "readme": "README.md",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Breaking change
- #135 
  * [svgo v3](https://github.com/svg/svgo/releases/tag/v3.0.0) introduced some breaking changes.
  * Notably `cleanupIDs` plugin has been renamed to `cleanupIds`
  ``` yml
  minify:
    svg:
      plugins:
        # new
        cleanupIds: true
        # old
        cleanupIDs: true
  ```

## Feature
- ci(tester): add node 19

## Housekeeping
- #133 
- chore(deps-dev): bump jest from 28.1.3 to 29.1.2  5453fc9ee05d0484803ba794ea10a44a78c07e7e