### PR TITLE
feat: previewServer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ npm install hexo-yam --save
 ``` yaml
 minify:
   enable: true
+  previewServer: true
   html:
   css:
   js:
@@ -45,6 +46,7 @@ minify:
 ```
 
 - **enable** - Enable the plugin. Defaults to `true`.
+- **previewServer** - Disable the plugin when running `hexo server`. Defaults to `true`.
 - **html** - See [HTML](#html) section
 - **css** - See [CSS](#css) section
 - **js** - See [JS](#js) section

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 'use strict'
 
 hexo.config.minify = Object.assign({
-  enable: true
+  enable: true,
+  previewServer: true
 }, hexo.config.minify)
 
 hexo.config.minify.html = Object.assign({
@@ -85,7 +86,7 @@ hexo.config.minify.json = Object.assign({
   globOptions: { basename: true }
 }, hexo.config.minify.json)
 
-if (hexo.config.minify.enable === true) {
+if (hexo.config.minify.enable === true && !(hexo.config.minify.previewServer === true && ['s', 'server'].includes(hexo.env.cmd))) {
   const filter = require('./lib/filter')
   hexo.extend.filter.register('after_render:html', filter.minifyHtml, hexo.config.minify.html.priority)
   hexo.extend.filter.register('after_render:css', filter.minifyCss, hexo.config.minify.css.priority)


### PR DESCRIPTION
BREAKING CHANGE
plugin is now disabled by default when running `hexo server`, unless previewServer is set to false.

Close #154
Inspired by https://github.com/Lete114/hexo-minify/blob/e778c55f37733680f7c727a7dd6e3507e1147c88/index.js#L49