### PR TITLE
Upgrade to HTML Minifier Next?

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { minify: htmlMinify } = require('html-minifier-terser')
+const { minify: htmlMinify } = require('html-minifier-next')
 const CleanCSS = require('clean-css')
 const { minify: terserMinify } = require('terser')
 const { optimize: svgOptimize } = require('svgo')

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
     "url": "git+https://github.com/curbengh/hexo-yam.git"
   },
   "dependencies": {
-    "clean-css": "^5.1.2",
-    "html-minifier-terser": "^7.2.0",
-    "micromatch": "^4.0.2",
-    "minify-xml": "^3.2.0",
-    "svgo": "^4.0.0",
-    "terser": "^5.3.0"
+    "clean-css": "^5.3.3",
+    "html-minifier-next": "^6.2.11",
+    "micromatch": "^4.0.8",
+    "minify-xml": "^3.5.0",
+    "svgo": "^4.0.1",
+    "terser": "^5.48.0"
   },
   "devDependencies": {
     "hexo": "^8.1.2",
-    "jest": "^30.0.4",
-    "standard": "^17.0.0"
+    "jest": "^30.4.2",
+    "standard": "^17.1.2"
   },
   "keywords": [
     "minify",

--- a/test/html.test.js
+++ b/test/html.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const Hexo = require('hexo')
-const { minify: htmlMinify } = require('html-minifier-terser')
+const { minify: htmlMinify } = require('html-minifier-next')
 
 describe('html', () => {
   const hexo = new Hexo(__dirname)
@@ -127,6 +127,6 @@ describe('html', () => {
   test('invalid string', async () => {
     const invalid = '<html><>?:"{}|_+</html>'
 
-    await expect(h(invalid, { path })).rejects.toThrow('Parse Error: <>?:"{}|_+</html>')
+    await expect(h(invalid, { path })).rejects.toThrow('Parse error at line 1, column 7')
   })
 })


### PR DESCRIPTION
The PR proposes [HTML Minifier Next (HMN)](https://www.npmjs.com/package/html-minifier-next) as a compatible, maintained, and faster alternative to HTML Minifier Terser (HMN is the official successor to [HTML Minifier](https://github.com/kangax/html-minifier)).

HMN is largely compatible, though there are [major changes](https://github.com/j9t/html-minifier-next/blob/main/CHANGELOG.md), new flags, and some convenience features (like presets) that should be worth noting (I’d recommend to point users to the changelog, for easy upgrading).

(Heads-up on HMN: The next major version is going ESM-only, which means it can’t be loaded via `require()` and won’t be a drop-in upgrade here. The runtime side is easy [`minifyHtml` is already async and can switch to a dynamic `import()`], but the Jest suite can’t load an ESM-only dependency as currently configured—so HMN 7 would require a Jest ESM migration [upside: the same work would also allow to move minify-xml to v4]. No action needed for this PR; just flagging that when HMN 7 lands you’d need to decide between staying on HMN 6 or doing a dedicated PR to convert the test setup to ESM.)

Btw, I felt free to bump all dependencies while working on this.

Happy to help a bit more, but as I maintain HMN I also don’t want to impose. Cheers!